### PR TITLE
Enhance cache.rs with robust error handling for poisoned RwLock and comprehensive tests

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,8 @@ pub enum CheckSSLError {
     OcspError(String),
     CrlError(String),
     IoError(io::Error),
+    /// Error when acquiring RwLock (usually due to poisoning)
+    LockError(String),
 }
 
 impl fmt::Display for CheckSSLError {
@@ -54,6 +56,7 @@ impl fmt::Display for CheckSSLError {
             CheckSSLError::OcspError(msg) => write!(f, "OCSP error: {}", msg),
             CheckSSLError::CrlError(msg) => write!(f, "CRL error: {}", msg),
             CheckSSLError::IoError(err) => write!(f, "IO error: {}", err),
+            CheckSSLError::LockError(msg) => write!(f, "Lock error: {}", msg),
         }
     }
 }

--- a/tests/enhanced_features_tests.rs
+++ b/tests/enhanced_features_tests.rs
@@ -63,7 +63,7 @@ fn test_certificate_cache_operations() {
     assert_eq!(key1, key2); // Should be case-insensitive
     
     // Test cache statistics
-    let stats = cache.statistics();
+    let stats = cache.statistics().unwrap();
     assert_eq!(stats.hits, 0);
     assert_eq!(stats.misses, 0);
 }
@@ -204,18 +204,18 @@ fn test_cache_eviction_strategies() {
         ..Default::default()
     };
     
-    cache.put("key1".to_string(), cert1);
-    cache.put("key2".to_string(), cert2);
+    cache.put("key1".to_string(), cert1).unwrap();
+    cache.put("key2".to_string(), cert2).unwrap();
     
     // Access key1 to make it more recently used
-    let _ = cache.get("key1");
+    let _ = cache.get("key1").unwrap();
     
     // Adding key3 should evict key2 (least recently used)
-    cache.put("key3".to_string(), cert3);
+    cache.put("key3".to_string(), cert3).unwrap();
     
-    assert!(cache.contains("key1"));
-    assert!(!cache.contains("key2"));
-    assert!(cache.contains("key3"));
+    assert!(cache.contains("key1").unwrap());
+    assert!(!cache.contains("key2").unwrap());
+    assert!(cache.contains("key3").unwrap());
 }
 
 #[test]
@@ -329,12 +329,12 @@ fn test_cache_ttl_expiration() {
         ..Default::default()
     };
     
-    cache.put("test_key".to_string(), cert);
-    assert!(cache.contains("test_key"));
+    cache.put("test_key".to_string(), cert).unwrap();
+    assert!(cache.contains("test_key").unwrap());
     
     // Wait for TTL to expire
     std::thread::sleep(Duration::from_millis(60));
     
-    assert!(!cache.contains("test_key"));
-    assert!(cache.get("test_key").is_none());
+    assert!(!cache.contains("test_key").unwrap());
+    assert!(cache.get("test_key").unwrap().is_none());
 }


### PR DESCRIPTION
## Summary
- Replaced all `unwrap()` calls on RwLock operations in `src/cache.rs` with proper error handling
- Added `LockError` variant to `CheckSSLError` enum for handling poisoned lock scenarios
- Made the cache operations more robust and panic-resistant
- Added extensive tests to verify handling of poisoned locks and error propagation

## Changes
- **Error Handling**: All RwLock operations now use `map_err()` to convert lock errors into `CheckSSLError::LockError`
- **API Changes**: Updated method signatures to return `Result` types:
  - `get()` now returns `Result<Option<Cert>, CheckSSLError>`
  - `put()` now returns `Result<(), CheckSSLError>`
  - `clear()` now returns `Result<(), CheckSSLError>`
  - `remove_expired()` now returns `Result<usize, CheckSSLError>`
  - `statistics()` now returns `Result<CacheStatistics, CheckSSLError>`
  - `size()` now returns `Result<usize, CheckSSLError>`
  - `contains()` now returns `Result<bool, CheckSSLError>`
  - `get_cached_domains()` now returns `Result<Vec<String>, CheckSSLError>`
  - `get_entry_details()` now returns `Result<Option<CacheEntryDetails>, CheckSSLError>`
- **Tests**: Added new tests to cover:
  - Handling of poisoned locks for cache and stats RwLocks
  - Error propagation in `check_with_cache` function
  - Verification that all cache methods handle lock errors gracefully

## Rationale
RwLock's `unwrap()` calls can panic if the lock is poisoned, which happens when a thread panics while holding the lock. This makes the application vulnerable to cascading failures. By properly handling these errors, we ensure the cache remains operational even in adverse conditions.

## Test Plan
✅ Added comprehensive tests for lock poisoning scenarios:
- `test_lock_poisoning_handling`: Verifies that operations return `LockError` when lock is poisoned
- `test_all_methods_handle_lock_errors`: Tests all cache methods handle poisoned locks correctly
- `test_error_propagation_in_check_with_cache`: Ensures error propagation works in the wrapper function

✅ All existing tests updated and passing:
- Cache module tests: 8 passed
- Integration tests: All passing
- Library tests: 58 passed

## Breaking Changes
This is a breaking change for users of the cache module as all methods now return `Result` types. Users will need to handle the potential errors with `?` or `unwrap()`.

🤖 Generated with [Claude Code](https://claude.ai/code)

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/2fd60a9b-6da7-4e86-9ec2-b902003ce230